### PR TITLE
Check if loc index exists

### DIFF
--- a/src/Geocoder/Provider/IpInfoProvider.php
+++ b/src/Geocoder/Provider/IpInfoProvider.php
@@ -40,7 +40,7 @@ class IpInfoProvider extends AbstractProvider implements ProviderInterface
         $content = $this->getAdapter()->getContent($query);
         $data    = json_decode($content, true);
 
-        if (empty($data) || '' === $data['loc']) {
+        if (empty($data) || !isset($data['loc']) || '' === $data['loc']) {
             throw new NoResultException(sprintf('Could not execute query %s', $query));
         }
 


### PR DESCRIPTION
There is no "loc" index in some results and it causes an error.

Example: http://ipinfo.io/192.168.10.1

192.168.10.1 is used in Laravel Homestead (on Vagrant)